### PR TITLE
Fix polyjuice build

### DIFF
--- a/packages/demo/tsconfig.json
+++ b/packages/demo/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2015",
+    "target": "es2020",
     "module": "commonjs",
     "declaration": true,
     "outDir": "./build",

--- a/packages/tools/src/polyjuice-cli.ts
+++ b/packages/tools/src/polyjuice-cli.ts
@@ -48,7 +48,7 @@ program
   .description("Call a EVM contract")
   .action(call)
 program
-  .command("staticCall <to_id> <input_data> <rollup_type_hash> <privkey>")
+  .command("staticCall <gas_limit> <gas_price> <to_id> <input_data> <rollup_type_hash> <privkey>")
   .description("Static Call a EVM contract")
   .action(staticCall)
 program.parse(argv);
@@ -88,7 +88,7 @@ async function deploy(
   privkey: string,
 ) {
   const creator_account_id = parseInt(creator_account_id_str);
-  const gas_lmit = BigInt(gas_limit_str);
+  const gas_limit = BigInt(gas_limit_str);
   const gas_price = BigInt(gas_price_str);
   const godwoken = new Godwoken(program.rpc);
   const polyjuice = new Polyjuice(godwoken, {
@@ -139,7 +139,7 @@ async function _call(
     console.log("Can not find account id by script_hash:", script_hash);
     exit(-1);
   }
-  const gas_lmit = BigInt(gas_limit_str);
+  const gas_limit = BigInt(gas_limit_str);
   const gas_price = BigInt(gas_price_str);
   const nonce = await godwoken.getNonce(from_id);
   const raw_l2tx = polyjuice.generateTransaction(from_id, parseInt(to_id_str), gas_limit, gas_price, 0n, input_data, nonce);
@@ -154,6 +154,8 @@ async function _call(
 
 async function call(
   to_id_str: string,
+  gas_limit_str: string,
+  gas_price_str: string,
   input_data: string,
   rollup_type_hash: string,
   privkey: string,
@@ -161,12 +163,14 @@ async function call(
   const godwoken = new Godwoken(program.rpc);
   _call(
     godwoken.submitL2Transaction.bind(godwoken),
-    to_id_str, input_data, rollup_type_hash, privkey,
+    to_id_str, gas_limit_str, gas_price_str, input_data, rollup_type_hash, privkey,
   );
 }
 
 async function staticCall(
   to_id_str: string,
+  gas_limit_str: string,
+  gas_price_str: string,
   input_data: string,
   rollup_type_hash: string,
   privkey: string,
@@ -174,7 +178,7 @@ async function staticCall(
   const godwoken = new Godwoken(program.rpc);
   _call(
     godwoken.executeL2Transaction.bind(godwoken),
-    to_id_str, input_data, rollup_type_hash, privkey,
+    to_id_str, gas_limit_str, gas_price_str, input_data, rollup_type_hash, privkey,
   );
 }
 


### PR DESCRIPTION
I meet these two problem:
First commit to resolve:
```
~/Workspace/godwoken-examples develop ?2 ❯ yarn workspace @godwoken-examples/demo clean-cli && yarn workspace @godwoken-examples/demo build-cli
yarn workspace v1.22.5
yarn run v1.22.5
$ rm -rf build-cli
Done in 0.04s.
Done in 0.24s.
yarn workspace v1.22.5
yarn run v1.22.5
$ tsc --build tsconfig.json ./src/cli
src/js/polyjuice.ts:159:5 - error TS2737: BigInt literals are not available when targeting lower than ES2020.

159     0n,
        ~~

src/js/polyjuice.ts:161:5 - error TS2737: BigInt literals are not available when targeting lower than ES2020.

161     0n,
        ~~


Found 2 errors.

```
Second commit to resolve
```
~/Workspace/godwoken-examples develop !1 ?2 ❯ yarn workspace @godwoken-examples/tools tsc                                                      5s

yarn workspace v1.22.5
yarn run v1.22.5
$ /home/zmc/Workspace/godwoken-examples/node_modules/.bin/tsc
src/polyjuice-cli.ts:106:62 - error TS2552: Cannot find name 'gas_limit'. Did you mean 'gas_lmit'?

106   const raw_l2tx = polyjuice.generateTransaction(from_id, 0, gas_limit, gas_price, 0n, init_code, nonce);
                                                                 ~~~~~~~~~

  src/polyjuice-cli.ts:91:9
    91   const gas_lmit = BigInt(gas_limit_str);
               ~~~~~~~~
    'gas_lmit' is declared here.

src/polyjuice-cli.ts:145:80 - error TS2552: Cannot find name 'gas_limit'. Did you mean 'gas_lmit'?

145   const raw_l2tx = polyjuice.generateTransaction(from_id, parseInt(to_id_str), gas_limit, gas_price, 0n, input_data, nonce);
                                                                                   ~~~~~~~~~

  src/polyjuice-cli.ts:142:9
    142   const gas_lmit = BigInt(gas_limit_str);
                ~~~~~~~~
    'gas_lmit' is declared here.

src/polyjuice-cli.ts:162:3 - error TS2554: Expected 7 arguments, but got 5.

162   _call(
      ~~~~~~
163     godwoken.submitL2Transaction.bind(godwoken),
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
164     to_id_str, input_data, rollup_type_hash, privkey,
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
165   );
    ~~~

  src/polyjuice-cli.ts:127:3
    127   rollup_type_hash: string,
          ~~~~~~~~~~~~~~~~~~~~~~~~
    An argument for 'rollup_type_hash' was not provided.

src/polyjuice-cli.ts:175:3 - error TS2554: Expected 7 arguments, but got 5.

175   _call(
      ~~~~~~
176     godwoken.executeL2Transaction.bind(godwoken),
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
177     to_id_str, input_data, rollup_type_hash, privkey,
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
178   );
    ~~~

  src/polyjuice-cli.ts:127:3
    127   rollup_type_hash: string,
          ~~~~~~~~~~~~~~~~~~~~~~~~
    An argument for 'rollup_type_hash' was not provided.


Found 4 errors.

```