### PR TITLE
fix: get current balance before withdrawal and deposit

### DIFF
--- a/packages/tools/src/account/deposit-ckb.ts
+++ b/packages/tools/src/account/deposit-ckb.ts
@@ -124,6 +124,13 @@ export const run = async (program: commander.Command) => {
 
   console.log("using eth address:", ethAddress);
   try {
+    const accountScriptHash = ethAddressToScriptHash(ethAddress);
+    const currentBalance = await getBalanceByScriptHash(
+      godwoken,
+      1,
+      accountScriptHash
+    );
+
     const txHash: Hash = await sendTx(
       deploymentConfig,
       ckbAddress,
@@ -133,18 +140,10 @@ export const run = async (program: commander.Command) => {
       privateKey,
       program.rpc
     );
-
-    console.log("txHash:", txHash);
-
-    console.log("--------- wait for tx deposit ----------");
+    console.log("Transaction hash:", txHash);
+    console.log("--------- wait for deposit transaction ----------");
 
     await waitTxCommitted(txHash, ckbRpc);
-    const accountScriptHash = ethAddressToScriptHash(ethAddress);
-    const currentBalance = await getBalanceByScriptHash(
-      godwoken,
-      1,
-      accountScriptHash
-    );
     await waitForDeposit(godwoken, accountScriptHash, currentBalance);
 
     process.exit(0);

--- a/packages/tools/src/account/deposit-sudt.ts
+++ b/packages/tools/src/account/deposit-sudt.ts
@@ -145,6 +145,13 @@ export const run = async (program: commander.Command) => {
   const godwoken = new Godwoken(godwokenRpc);
 
   try {
+    const accountScriptHash = ethAddressToScriptHash(ethAddress);
+    const currentBalance = await getBalanceByScriptHash(
+      godwoken,
+      1,
+      accountScriptHash
+    );
+
     const [txHash, layer2SudtScriptHash] = await sendTx(
       godwoken,
       deploymentConfig,
@@ -158,17 +165,10 @@ export const run = async (program: commander.Command) => {
       capacity
     );
 
-    console.log("txHash:", txHash);
-
-    console.log("--------- wait for tx deposit ----------");
+    console.log("Transaction hash:", txHash);
+    console.log("--------- wait for token deposit transaction ----------");
 
     await waitTxCommitted(txHash, ckbRpc);
-    const accountScriptHash = ethAddressToScriptHash(ethAddress);
-    const currentBalance = await getBalanceByScriptHash(
-      godwoken,
-      1,
-      accountScriptHash
-    );
     await waitForDeposit(
       godwoken,
       accountScriptHash,

--- a/packages/tools/src/account/withdraw.ts
+++ b/packages/tools/src/account/withdraw.ts
@@ -67,6 +67,12 @@ export const run = async (program: Command) => {
 
   const godwoken = new Godwoken(program.parent.godwokenRpc);
   try {
+    const currentBalance = await getBalanceByScriptHash(
+      godwoken,
+      1,
+      accountScriptHash
+    );
+
     await withdrawal(
       godwoken,
       privateKey,
@@ -78,11 +84,6 @@ export const run = async (program: Command) => {
       feeAmount
     );
 
-    const currentBalance = await getBalanceByScriptHash(
-      godwoken,
-      1,
-      accountScriptHash
-    );
     await waitForWithdraw(godwoken, accountScriptHash, currentBalance);
 
     process.exit(0);


### PR DESCRIPTION
With the `Instant finality` feature of Godwoken,
we should get current balance before deposit and withdrawal.